### PR TITLE
Fix the shebang of Python scripts

### DIFF
--- a/_amt_test.py
+++ b/_amt_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/_amtanalyser_test.py
+++ b/_amtanalyser_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import configparser

--- a/_amtlauncher_test.py
+++ b/_amtlauncher_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import configparser

--- a/_amtlcs_test.py
+++ b/_amtlcs_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/_amtutils_test.py
+++ b/_amtutils_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/_gen_additions_test.py
+++ b/_gen_additions_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/_gen_deletions_test.py
+++ b/_gen_deletions_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/_gen_simplify_test.py
+++ b/_gen_simplify_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/_gen_woven_test.py
+++ b/_gen_woven_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import unittest

--- a/amt.py
+++ b/amt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/amtanalyser.py
+++ b/amtanalyser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from amtutils import *

--- a/amtlauncher.py
+++ b/amtlauncher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import inspect

--- a/amtlcs.py
+++ b/amtlcs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 

--- a/amtutils.py
+++ b/amtutils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os

--- a/gen_additions.py
+++ b/gen_additions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/gen_debug.py
+++ b/gen_debug.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys

--- a/gen_deletions.py
+++ b/gen_deletions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import sys

--- a/gen_simplify.py
+++ b/gen_simplify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/gen_woven.py
+++ b/gen_woven.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import argparse

--- a/java_imports.py
+++ b/java_imports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import argparse


### PR DESCRIPTION
Make it work on systems where the Python3 binary is called python3 (for example Ubuntu 16.04) and/or is not installed in /usr/bin.